### PR TITLE
Add seed bonus announce/batch/job traceability

### DIFF
--- a/app/Console/Commands/UserSeedBonusTrace.php
+++ b/app/Console/Commands/UserSeedBonusTrace.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Repositories\CleanupRepository;
+use Illuminate\Console\Command;
+
+class UserSeedBonusTrace extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:seed-bonus-trace {uid : User ID}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show latest announce, cleanup batch record and seed bonus job trace for a user.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $uid = (int)$this->argument('uid');
+        if ($uid <= 0) {
+            $this->error('uid must be a positive integer.');
+            return self::FAILURE;
+        }
+
+        $trace = CleanupRepository::getUserSeedBonusTrace($uid);
+        if (empty($trace)) {
+            $this->warn("No seed bonus trace found for user ID: $uid");
+            $this->line('Trace is stored for the latest 24 hours after announce/batch/job activity.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Latest seed bonus trace for user ID: $uid");
+        $this->line(json_encode($trace, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        return self::SUCCESS;
+    }
+}

--- a/app/Jobs/CalculateUserSeedBonus.php
+++ b/app/Jobs/CalculateUserSeedBonus.php
@@ -6,6 +6,7 @@ use App\Models\BonusLogs;
 use App\Models\IpLog;
 use App\Models\Setting;
 use App\Models\User;
+use App\Repositories\CleanupRepository;
 use App\Repositories\IpLogRepository;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -158,6 +159,24 @@ class CalculateUserSeedBonus implements ShouldQueue
 //            $sql = "update users set seed_points = ifnull(seed_points, 0) + $seed_points, seed_points_per_hour = {$seedBonusResult['seed_points']}, seedbonus = seedbonus + $all_bonus, seed_points_updated_at = '$updatedAt' where id = $uid limit 1";
 //            do_log("$bonusLog, query: $sql");
 //            NexusDB::statement($sql);
+            $jobUserTrace = [
+                'recorded_at' => now()->toDateTimeString(),
+                'request_id' => $this->requestId,
+                'uid' => (int)$uid,
+                'id_redis_key' => $this->idRedisKey,
+                'seed_points_before' => $userInfo['seed_points'],
+                'seed_points_delta' => $seed_points,
+                'seed_points_after' => $userInfo['seed_points'] + $seed_points,
+                'seedbonus_before' => $userInfo['seedbonus'],
+                'seedbonus_delta' => $all_bonus,
+                'seedbonus_after' => $userInfo['seedbonus'] + $all_bonus,
+                'seed_points_per_hour' => $seedBonusResult['seed_points'],
+                'seed_bonus_per_hour' => $seedBonusResult['seed_bonus'],
+                'torrent_peer_count' => $seedBonusResult['torrent_peer_count'],
+                'seeding_size' => $seedBonusResult['size'],
+            ];
+            CleanupRepository::putUserSeedBonusTrace((int)$uid, 'seed_bonus_job', $jobUserTrace);
+            do_log('[SEED_BONUS_TRACE][SEED_BONUS_JOB_USER] ' . nexus_json_encode($jobUserTrace));
             $seedPointsUpdates[] = sprintf("when %d then ifnull(seed_points, 0) + %f", $uid, $seed_points);
             $seedPointsPerHourUpdates[] = sprintf("when %d then %f", $uid, $seedBonusResult['seed_points']);
             $seedBonusPerHourUpdates[] = sprintf("when %d then %f", $uid, $seedBonusResult['seed_bonus']);

--- a/app/Repositories/CleanupRepository.php
+++ b/app/Repositories/CleanupRepository.php
@@ -17,6 +17,8 @@ class CleanupRepository extends BaseRepository
     const TORRENT_SEEDERS_ETC_BATCH_KEY = "batch_key:torrent_seeders_etc";
 
     const IDS_KEY_PREFIX = "cleanup_batch_job_ids:";
+    public const USER_SEED_BONUS_TRACE_CACHE_KEY_PREFIX = "user_seed_bonus_trace:";
+    private const USER_SEED_BONUS_TRACE_TTL = 86400;
 
     private static array $batchKeyActionsMap = [
         self::USER_SEED_BONUS_BATCH_KEY => [
@@ -47,6 +49,25 @@ class CleanupRepository extends BaseRepository
         ];
         $result  = $redis->eval(self::getAddRecordLuaScript(), $args, 3);
         $err = $redis->getLastError();
+        $batchKeys = $redis->mGet([
+            self::USER_SEED_BONUS_BATCH_KEY,
+            self::USER_SEEDING_LEECHING_TIME_BATCH_KEY,
+            self::TORRENT_SEEDERS_ETC_BATCH_KEY,
+        ]);
+        $record = [
+            'recorded_at' => now()->toDateTimeString(),
+            'uid' => (int)$uid,
+            'torrent_id' => (int)$torrentId,
+            'eval_result' => $result,
+            'redis_error' => $err ?: null,
+            'batch_keys' => [
+                self::USER_SEED_BONUS_BATCH_KEY => $batchKeys[0] ?? null,
+                self::USER_SEEDING_LEECHING_TIME_BATCH_KEY => $batchKeys[1] ?? null,
+                self::TORRENT_SEEDERS_ETC_BATCH_KEY => $batchKeys[2] ?? null,
+            ],
+        ];
+        self::putUserSeedBonusTrace((int)$uid, 'batch_record', $record);
+        do_log('[SEED_BONUS_TRACE][BATCH_RECORD] ' . nexus_json_encode($record));
         if ($err) {
             do_log("[REDIS_LUA_ERROR]: $err", "error");
         }
@@ -116,6 +137,21 @@ class CleanupRepository extends BaseRepository
                 $idStr = implode(",", $validFields);
                 $idRedisKey = self::IDS_KEY_PREFIX . Str::random();
                 NexusDB::cache_put($idRedisKey, $idStr);
+                $runBatchTrace = [
+                    'recorded_at' => now()->toDateTimeString(),
+                    'request_id' => $requestId,
+                    'batch_key' => $batchKey,
+                    'batch' => $batch,
+                    'page' => $page,
+                    'valid_user_id_count' => count($validFields),
+                    'dead_user_id_count' => count($toRemoveFields),
+                    'id_redis_key' => $idRedisKey,
+                    'id_str' => $idStr,
+                ];
+                do_log('[SEED_BONUS_TRACE][RUN_BATCH_JOB] ' . nexus_json_encode($runBatchTrace));
+                foreach ($validFields as $validUid) {
+                    self::putUserSeedBonusTrace((int)$validUid, 'run_batch_job', $runBatchTrace);
+                }
                 $command = sprintf(
                     'cleanup --action=%s --begin_id=%s --end_id=%s --id_redis_key=%s --request_id=%s --delay=%s',
                     $batchKeyInfo['action'], 0, 0,  $idRedisKey, $requestId, $delay
@@ -123,6 +159,19 @@ class CleanupRepository extends BaseRepository
                 $output = executeCommand($command, 'string', true);
                 do_log(sprintf('output: %s', $output));
                 $count += count($validFields);
+            }
+            if (empty($validFields)) {
+                $runBatchTrace = [
+                    'recorded_at' => now()->toDateTimeString(),
+                    'request_id' => $requestId,
+                    'batch_key' => $batchKey,
+                    'batch' => $batch,
+                    'page' => $page,
+                    'valid_user_id_count' => 0,
+                    'dead_user_id_count' => count($toRemoveFields),
+                    'id_redis_key' => null,
+                ];
+                do_log('[SEED_BONUS_TRACE][RUN_BATCH_JOB] ' . nexus_json_encode($runBatchTrace));
             }
             if (!empty($toRemoveFields)) {
                 $redis->hDel($batch, ...$toRemoveFields);
@@ -138,7 +187,25 @@ class CleanupRepository extends BaseRepository
         do_log(sprintf("$logPrefix, [DONE], batch: $batch, count: $count, cost time: %d seconds", $endTimestamp - $beginTimestamp));
     }
 
+    public static function putUserSeedBonusTrace(int $uid, string $type, array $payload): void
+    {
+        if ($uid <= 0) {
+            return;
+        }
+        $key = self::USER_SEED_BONUS_TRACE_CACHE_KEY_PREFIX . $uid;
+        $trace = NexusDB::cache_get($key);
+        if (!is_array($trace)) {
+            $trace = [];
+        }
+        $trace[$type] = $payload;
+        NexusDB::cache_put($key, $trace, self::USER_SEED_BONUS_TRACE_TTL);
+    }
 
+    public static function getUserSeedBonusTrace(int $uid): array
+    {
+        $trace = NexusDB::cache_get(self::USER_SEED_BONUS_TRACE_CACHE_KEY_PREFIX . $uid);
+        return is_array($trace) ? $trace : [];
+    }
 
     private static function getBatch(\Redis $redis, $batchKey)
     {

--- a/public/announce.php
+++ b/public/announce.php
@@ -630,6 +630,18 @@ if(count($USERUPDATESET) && $userid)
 }
 $lockKey = sprintf("record_batch_lock:%s:%s", $userid, $torrentid);
 if ($redis->set($lockKey, TIMENOW, ['nx', 'ex' => $autoclean_interval_one])) {
+    $announceTrace = [
+        'recorded_at' => date('Y-m-d H:i:s', TIMENOW),
+        'uid' => (int)$userid,
+        'torrent_id' => (int)$torrentid,
+        'event' => $_GET['event'] ?? '',
+        'left' => (int)$left,
+        'seeder' => $seeder,
+        'lock_key' => $lockKey,
+        'request_id' => nexus()->getRequestId(),
+    ];
+    \App\Repositories\CleanupRepository::putUserSeedBonusTrace((int)$userid, 'announce', $announceTrace);
+    do_log('[SEED_BONUS_TRACE][ANNOUNCE] ' . nexus_json_encode($announceTrace));
     \App\Repositories\CleanupRepository::recordBatch($redis, $userid, $torrentid);
     \App\Repositories\IpLogRepository::saveToCache($userid, null, [$ip]);
 }


### PR DESCRIPTION
### Motivation
- Improve observability across the announce → batch recording → cleanup job → seed bonus job path to help debug users who are seeding but not receiving seed bonus. 
- Capture structured trace data per user for a short retention window so operators can quickly inspect the latest announce/batch/job state for a user.

### Description
- Add per-user trace cache and helpers `CleanupRepository::putUserSeedBonusTrace` and `CleanupRepository::getUserSeedBonusTrace` with a 24-hour TTL and new cache key prefix `user_seed_bonus_trace:` in `app/Repositories/CleanupRepository.php`.
- In `public/announce.php` record an announce trace (user id, torrent id, event, left, seeder, lock key, request id) and log it (`[SEED_BONUS_TRACE][ANNOUNCE]`) before calling `recordBatch()`.
- In `CleanupRepository::recordBatch()` record the Redis `eval` return value, any Redis error, user id, torrent id and current batch keys and log/store the snapshot as `batch_record` for the user.
- In `CleanupRepository::runBatchJob()` emit page-level `RUN_BATCH_JOB` traces including `valid_user_id_count`, `dead_user_id_count`, generated `id_redis_key`, and `id_str`, and store the `run_batch_job` trace for every valid user in the page.
- In `CalculateUserSeedBonus::handle()` emit a per-user `seed_bonus_job` trace prior to performing the bulk update that includes `seed_points`/`seedbonus` before, delta and after values, `id_redis_key`, hourly rates and seeding stats, and log it (`[SEED_BONUS_TRACE][SEED_BONUS_JOB_USER]`).
- Add an Artisan command `user:seed-bonus-trace {uid}` at `app/Console/Commands/UserSeedBonusTrace.php` to print the latest announce/batch/run_batch/job traces for a given user id.

### Testing
- Ran PHP syntax checks: `php -l app/Repositories/CleanupRepository.php`, `php -l public/announce.php`, `php -l app/Jobs/CalculateUserSeedBonus.php`, and `php -l app/Console/Commands/UserSeedBonusTrace.php`; all returned no syntax errors.
- Attempt to list the new Artisan command with `php artisan list user --raw | rg "user:seed-bonus-trace"` was blocked in this environment because `vendor/autoload.php` is missing, so runtime command verification was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a335276b2ac83299515bbbc7b6a70c7)