### PR TITLE
Prevent premature expiry of USER_SEED_BONUS batch entries

### DIFF
--- a/app/Repositories/CleanupRepository.php
+++ b/app/Repositories/CleanupRepository.php
@@ -39,6 +39,9 @@ class CleanupRepository extends BaseRepository
 
     private static int $scanSize = 500;
 
+    private const ANNOUNCE_INTERVAL_JITTER_SECONDS = 100;
+
+
     public static function recordBatch(\Redis $redis, $uid, $torrentId)
     {
         $args = [
@@ -94,7 +97,7 @@ class CleanupRepository extends BaseRepository
             $redis->expire($newBatch, $lifeTime);
         }
 
-        $userSeedBonusDeadline = deadtime();
+        $userSeedBonusDeadline = self::getUserSeedBonusBatchDeadline();
         $count = 0;
         $it = NULL;
         $length = $redis->hLen($batch);
@@ -107,6 +110,12 @@ class CleanupRepository extends BaseRepository
             foreach ($arr_keys as $field => $value) {
                 if ($batchKey == self::USER_SEED_BONUS_BATCH_KEY && $value < $userSeedBonusDeadline) {
                     //dead, should remove
+                    do_log(sprintf(
+                        "[USER_SEED_BONUS_BATCH_EXPIRED], user_id: %s, recorded_at: %s, deadtime: %s",
+                        $field,
+                        $value,
+                        $userSeedBonusDeadline
+                    ));
                     $toRemoveFields[] = $field;
                 } else {
                     $validFields[] = $field;
@@ -235,7 +244,47 @@ LUA;
         $four = self::getInterval("four");
         $three = self::getInterval("three");
         $one = self::getInterval("one");
-        return intval($four) + intval($three) + intval($one);
+        return max(
+            intval($four) + intval($three) + intval($one),
+            self::getSeedBonusBatchLifeTime()
+        );
+    }
+
+    private static function getUserSeedBonusBatchDeadline(): int
+    {
+        return time() - self::getSeedBonusBatchLifeTime();
+    }
+
+    private static function getSeedBonusBatchLifeTime(): int
+    {
+        return max(
+            self::getDeadtimeLifeTime(),
+            self::getMaxTrackerAnnounceInterval() + self::getInterval("one") + self::getMaxQueueDelay(self::$batchKeyActionsMap[self::USER_SEED_BONUS_BATCH_KEY]['task_index'])
+        );
+    }
+
+    private static function getDeadtimeLifeTime(): int
+    {
+        return (int)floor(self::getIntervalSetting("main.anninterthree") * 1.3);
+    }
+
+    private static function getMaxTrackerAnnounceInterval(): int
+    {
+        return max(
+            self::getIntervalSetting("main.announce_interval"),
+            self::getIntervalSetting("main.annintertwo"),
+            self::getIntervalSetting("main.anninterthree")
+        ) + self::ANNOUNCE_INTERVAL_JITTER_SECONDS;
+    }
+
+    private static function getMaxQueueDelay(int $taskIndex): int
+    {
+        return (int)(self::getDelayBase($taskIndex) + self::getOneTaskSeconds());
+    }
+
+    private static function getIntervalSetting(string $name): int
+    {
+        return intval(get_setting($name));
     }
 
     private static function getInterval($level): int


### PR DESCRIPTION
### Motivation
- Avoid valid seeding users being removed from the seed-bonus batch due to timing mismatches between tracker announce intervals, `deadtime()`, cleanup intervals and queue scheduling delays.
- Ensure the Redis batch key lifetime and the expiry cutoff used when cleaning `USER_SEED_BONUS` entries always cover the worst-case announce + cleanup + queue delay window.

### Description
- Replace direct use of `deadtime()` in batch processing with `getUserSeedBonusBatchDeadline()` which computes a safe cutoff using `getSeedBonusBatchLifeTime()`; the new logic factors in `deadtime()` lifetime, the maximum tracker announce interval, the priority one cleanup interval and the maximum queue delay.
- Ensure `getCacheKeyLifeTime()` never returns a TTL shorter than the seed-bonus safety window by taking `max(current_cache_ttl, seed_bonus_life_time)`.
- Add a small jitter constant `ANNOUNCE_INTERVAL_JITTER_SECONDS` and helpers `getMaxTrackerAnnounceInterval()`, `getMaxQueueDelay()` and `getIntervalSetting()` to compute conservative timing bounds.
- Log removals of seed-bonus batch entries by printing user id, recorded timestamp and computed cutoff when an entry is considered expired.

### Testing
- Ran `php -l app/Repositories/CleanupRepository.php` with no syntax errors reported and it returned success.
- Ran `php -l public/announce.php` and `php -l include/functions.php` with no syntax errors reported and both returned success.
- Ran `git diff --check` to validate whitespace/problems and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33527bf2b88329af998d3cb8692757)